### PR TITLE
core/inc/camera.h: use const char for the camera identifier

### DIFF
--- a/core/inc/camera.h
+++ b/core/inc/camera.h
@@ -27,7 +27,7 @@ typedef struct br_camera {
     /*
      * Optional identifier
      */
-    char *identifier;
+    const char *identifier;
 
     /*
      * Type of camera


### PR DESCRIPTION
Otherwise a static initialiser of the form:

    br_camera cam = { "myid", .... };

fails when using a modern C++ compiler without permissive mode enabled due to the ISO C++ standard forbidding a cast from const char * to char *.