### PR TITLE
cmake: use project source directory to locate mkdrv.pl

### DIFF
--- a/cmake/h2inc.cmake
+++ b/cmake/h2inc.cmake
@@ -1,5 +1,5 @@
 function(make_h2inc TARGET SRC DST)
-    set(mkdrv "${CMAKE_SOURCE_DIR}/contrib/mkdrv.pl")
+    set(mkdrv "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../contrib/mkdrv.pl")
     set(target_includes "$<TARGET_PROPERTY:${TARGET},INCLUDE_DIRECTORIES>")
 
     add_custom_command(


### PR DESCRIPTION
When building BRender as part of another CMake project, the `h2inc.cmake` script will fail to locate `mkdrv.pl`. This is because it is using the `CMAKE_SOURCE_DIR` variable, which will be set to the location of the outer project's sources instead of the BRender project's sources. This PR changes `h2inc.cmake` to use the BRender project's source directory to locate `mkdrv.pl`.