### PR TITLE
core/host/cpuinfo: fix sizeof(ptr) instead of sizeof(*ptr) on MSVC x64

### DIFF
--- a/core/host/cpuinfo.c
+++ b/core/host/cpuinfo.c
@@ -17,10 +17,10 @@ static int x86_cpuid(unsigned int leaf, unsigned int *_eax, unsigned int *_ebx, 
 {
     int CPUInfo[4];
     __cpuid(CPUInfo, leaf);
-    memcpy(_eax, CPUInfo + 0, sizeof(_eax));
-    memcpy(_ebx, CPUInfo + 1, sizeof(_ebx));
-    memcpy(_ecx, CPUInfo + 2, sizeof(_ecx));
-    memcpy(_edx, CPUInfo + 3, sizeof(_edx));
+    memcpy(_eax, CPUInfo + 0, sizeof(*_eax));
+    memcpy(_ebx, CPUInfo + 1, sizeof(*_ebx));
+    memcpy(_ecx, CPUInfo + 2, sizeof(*_ecx));
+    memcpy(_edx, CPUInfo + 3, sizeof(*_edx));
     return 1;
 }
 


### PR DESCRIPTION
## Summary

In the MSVC x64 build of `x86_cpuid()`, the four `memcpy` calls use `sizeof(_eax)` etc., where `_eax` is an `unsigned int *`. On 64-bit, `sizeof(unsigned int *)` is **8**, not 4, so each call copies 8 bytes into a 4-byte stack variable, corrupting adjacent stack variables.

This manifests as an MSVC `/RTC1` run-time check failure at startup:

> Run-Time Check Failure #2 – Stack around the variable 'ecx' was corrupted.

**Fix:** change `sizeof(_eax)` → `sizeof(*_eax)` (and likewise for `ebx`, `ecx`, `edx`) so the copy size is `sizeof(unsigned int)` = 4.

This bug only affects MSVC x64 builds; GCC uses `__get_cpuid` from `<cpuid.h>` which is unaffected.