### PR TITLE
docs: add macOS Apple Silicon build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,31 @@ cmake ..
 make
 ```
 
+### macOS (Apple Silicon)
+
+Install dependencies via [Homebrew](https://brew.sh):
+
+```sh
+brew install cmake sdl3 glslang spirv-cross
+```
+
+Then build with SDL3:
+
+```sh
+mkdir cmake-build && cd cmake-build
+cmake .. -DBRENDER_USE_SDL3=ON
+make -j$(sysctl -n hw.logicalcpu)
+```
+
+The x86 software renderer (`pentprim`) cannot be built on ARM — the OpenGL renderer is used instead. Everything else builds and runs correctly, including the sample apps.
+
+To try it out, run the forest demo from the build directory:
+
+```sh
+cd examples/samples/forest
+./forest
+```
+
 ## License
 
 This is released under the MIT license.


### PR DESCRIPTION
## Summary

- Adds a dedicated **macOS (Apple Silicon)** section under Building
- Lists the full Homebrew dependency set: `cmake`, `sdl3`, `glslang`, `spirv-cross`
- Shows the correct CMake flag (`-DBRENDER_USE_SDL3=ON`) and parallel build invocation
- Notes that the x86 software renderer (`pentprim`) can't be built on ARM
- Includes a quick example running the forest demo

## Test plan

- [ ] Tested end-to-end on M4 Mac (macOS 15, Apple Clang 17), OpenGL 4.1 Metal context
- [ ] `forest`, `cube`, tutorials, and tools all built successfully
- [ ] Forest demo ran correctly on first try