### PR TITLE
softrend: fix ARM64 variadic ABI crash

### DIFF
--- a/drivers/softrend/clip.c
+++ b/drivers/softrend/clip.c
@@ -435,7 +435,7 @@ void ClippedRenderTriangles(br_renderer *renderer, brp_block *block, brp_vertex 
      * Triangulate polygon
      */
     for(i = 2; i < n; i++)
-        block->render(block, &cp_in[0], &cp_in[i - 1], &cp_in[i], fp_vertices, fp_edges);
+        brp_render3_fp(block, &cp_in[0], &cp_in[i - 1], &cp_in[i], fp_vertices, fp_edges);
 }
 
 /*
@@ -627,5 +627,5 @@ void ClippedRenderLine(br_renderer *renderer, brp_block *block, brp_vertex *cp_i
     /*
      * Render the line
      */
-    block->render(block, &cp_in[0], &cp_in[1]);
+    brp_render2(block, &cp_in[0], &cp_in[1]);
 }

--- a/drivers/softrend/convert.c
+++ b/drivers/softrend/convert.c
@@ -75,7 +75,7 @@ void BR_ASM_CALL RenderConvert1(struct brp_block *block, brp_vertex *v0)
             if(m & 1)
                 outv[0].comp_i[c] = v0->comp_i[c];
 
-    block->chain->render(block->chain, outv);
+    brp_render1(block->chain, outv);
 }
 
 void BR_ASM_CALL RenderConvert2(struct brp_block *block, brp_vertex *v0, brp_vertex *v1)
@@ -115,7 +115,7 @@ void BR_ASM_CALL RenderConvert2(struct brp_block *block, brp_vertex *v0, brp_ver
                 outv[1].comp_i[c] = v1->comp_i[c];
             }
 
-    block->chain->render(block->chain, outv + 0, outv + 1);
+    brp_render2(block->chain, outv + 0, outv + 1);
 }
 
 void BR_ASM_CALL RenderConvert3(struct brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2)
@@ -159,7 +159,7 @@ void BR_ASM_CALL RenderConvert3(struct brp_block *block, brp_vertex *v0, brp_ver
                 outv[2].comp_i[c] = v2->comp_i[c];
             }
 
-    block->chain->render(block->chain, outv + 0, outv + 1, outv + 2);
+    brp_render3(block->chain, outv + 0, outv + 1, outv + 2);
 }
 
 void BR_ASM_CALL RenderConvert4(struct brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2, brp_vertex *v3)
@@ -207,5 +207,5 @@ void BR_ASM_CALL RenderConvert4(struct brp_block *block, brp_vertex *v0, brp_ver
                 outv[3].comp_i[c] = v3->comp_i[c];
             }
 
-    block->chain->render(block->chain, outv + 0, outv + 1, outv + 2, outv + 3);
+    brp_render4(block->chain, outv + 0, outv + 1, outv + 2, outv + 3);
 }

--- a/drivers/softrend/ddi/priminfo.h
+++ b/drivers/softrend/ddi/priminfo.h
@@ -230,6 +230,65 @@ typedef struct brp_block_min {
 
 } brp_block_min;
 
+/*
+ * Type-safe wrappers for calling through brp_render_fn pointers.
+ *
+ * brp_render_fn is variadic (...) to serve as a generic callback type. On x86,
+ * variadic and non-variadic ABIs are identical so calling through the variadic
+ * pointer is harmless. On ARM64 they diverge: variadic args go on the stack,
+ * but non-variadic callees expect them in registers. The result is silent
+ * argument corruption -- valid pointers arriving as garbage.
+ *
+ * These wrappers cast the pointer to the exact non-variadic type for each
+ * call site before calling. On x86 the casts compile to nothing.
+ *
+ *   brp_render1      block + 1 vertex                                         (point)
+ *   brp_render2      block + 2 vertices                                       (line)
+ *   brp_render3      block + 3 vertices                                       (triangle)
+ *   brp_render3_fp   block + 3 verts + fp_vertices + fp_edges                 (triangle + face-plane)
+ *   brp_render3_fpx  block + 3 verts + fp_vertices + fp_edges + fp_eqn + tfp  (triangle + full face-plane)
+ *   brp_render4      block + 4 vertices                                       (quad)
+ */
+#ifndef __H2INC__
+typedef void(BR_ASM_CALL *brp_render1_fn)(brp_block *, brp_vertex *);
+typedef void(BR_ASM_CALL *brp_render2_fn)(brp_block *, brp_vertex *, brp_vertex *);
+typedef void(BR_ASM_CALL *brp_render3_fn)(brp_block *, brp_vertex *, brp_vertex *, brp_vertex *);
+typedef void(BR_ASM_CALL *brp_render3_fp_fn)(brp_block *, brp_vertex *, brp_vertex *, brp_vertex *, void *, void *);
+typedef void(BR_ASM_CALL *brp_render3_fpx_fn)(brp_block *, brp_vertex *, brp_vertex *, brp_vertex *, void *, void *, void *, void *);
+typedef void(BR_ASM_CALL *brp_render4_fn)(brp_block *, brp_vertex *, brp_vertex *, brp_vertex *, brp_vertex *);
+
+static inline void brp_render1(brp_block *b, brp_vertex *v0)
+{
+    ((brp_render1_fn)b->render)(b, v0);
+}
+
+static inline void brp_render2(brp_block *b, brp_vertex *v0, brp_vertex *v1)
+{
+    ((brp_render2_fn)b->render)(b, v0, v1);
+}
+
+static inline void brp_render3(brp_block *b, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2)
+{
+    ((brp_render3_fn)b->render)(b, v0, v1, v2);
+}
+
+static inline void brp_render3_fp(brp_block *b, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2, void *e0, void *e1)
+{
+    ((brp_render3_fp_fn)b->render)(b, v0, v1, v2, e0, e1);
+}
+
+static inline void brp_render3_fpx(brp_block *b, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2, void *e0, void *e1, void *e2, void *e3)
+{
+    ((brp_render3_fpx_fn)b->render)(b, v0, v1, v2, e0, e1, e2, e3);
+}
+
+static inline void brp_render4(brp_block *b, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2, brp_vertex *v3)
+{
+    ((brp_render4_fn)b->render)(b, v0, v1, v2, v3);
+}
+
+#endif /* __H2INC__ */
+
 #ifdef __cplusplus
 }
 ;

--- a/drivers/softrend/faceops.c
+++ b/drivers/softrend/faceops.c
@@ -98,7 +98,7 @@ void BR_ASM_CALL OpTriangleConstantSurf(brp_block *block, brp_vertex *v0, brp_ve
     for(i = 0; i < rend.renderer->state.cache.nconstant_fns; i++)
         rend.renderer->state.cache.constant_fns[i](rend.renderer, vp_p, vp_map, (br_vector3 *)fp_eqn, colour, v0->comp);
 
-    block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges);
+    brp_render3_fp(block->chain, v0, v1, v2, fp_vertices, fp_edges);
 }
 
 void BR_ASM_CALL OpTriangleTwoSidedConstantSurf(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2, br_uint_16 (*fp_vertices)[3],
@@ -128,7 +128,7 @@ void BR_ASM_CALL OpTriangleTwoSidedConstantSurf(brp_block *block, brp_vertex *v0
             rend.renderer->state.cache.constant_fns[i](rend.renderer, vp_p, vp_map, (br_vector3 *)fp_eqn, colour, v0->comp);
     }
 
-    block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges);
+    brp_render3_fp(block->chain, v0, v1, v2, fp_vertices, fp_edges);
 }
 
 /*
@@ -171,7 +171,7 @@ void BR_ASM_CALL OpTriangleMappingWrapFix(brp_block *block, brp_vertex *v0, brp_
         }
     }
 
-    block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges, fp_eqn, tfp);
+    brp_render3_fpx(block->chain, v0, v1, v2, fp_vertices, fp_edges, fp_eqn, tfp);
 }
 
 /*
@@ -215,9 +215,9 @@ void BR_ASM_CALL OpTriangleRelightTwoSided(brp_block *block, brp_vertex *v0, brp
                     rend.renderer->state.cache.vertex_fns[i](rend.renderer, vp_p, vp_map, &rev_normal, colour, tv[v].comp);
             }
         }
-        block->chain->render(block->chain, tv + 0, tv + 1, tv + 2, fp_vertices, fp_edges, fp_eqn, tfp);
+        brp_render3_fpx(block->chain, tv + 0, tv + 1, tv + 2, fp_vertices, fp_edges, fp_eqn, tfp);
     } else {
-        block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges, fp_eqn, tfp);
+        brp_render3_fpx(block->chain, v0, v1, v2, fp_vertices, fp_edges, fp_eqn, tfp);
     }
 }
 
@@ -231,17 +231,17 @@ void BR_ASM_CALL OpTriangleToLines(brp_block *block, brp_vertex *v0, brp_vertex 
      * Generate a line for each unrendered edge
      */
     if(!rend.edge_flags[(*fp_edges)[0]]) {
-        block->chain->render(block->chain, v0, v1);
+        brp_render2(block->chain, v0, v1);
         rend.edge_flags[(*fp_edges)[0]] = 1;
     }
 
     if(!rend.edge_flags[(*fp_edges)[1]]) {
-        block->chain->render(block->chain, v1, v2);
+        brp_render2(block->chain, v1, v2);
         rend.edge_flags[(*fp_edges)[1]] = 1;
     }
 
     if(!rend.edge_flags[(*fp_edges)[2]]) {
-        block->chain->render(block->chain, v2, v0);
+        brp_render2(block->chain, v2, v0);
         rend.edge_flags[(*fp_edges)[2]] = 1;
     }
 }
@@ -263,7 +263,7 @@ void BR_ASM_CALL OpTriangleReplicateConstant(brp_block *block, brp_vertex *v0, b
             v1->comp[c] = v2->comp[c] = v0->comp[c];
     }
 
-    block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges);
+    brp_render3_fp(block->chain, v0, v1, v2, fp_vertices, fp_edges);
 }
 
 /*
@@ -274,7 +274,7 @@ void BR_ASM_CALL OpTriangleReplicateConstantI(brp_block *block, brp_vertex *v0, 
 {
     v1->comp[C_I] = v2->comp[C_I] = v0->comp[C_I];
 
-    block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges);
+    brp_render3_fp(block->chain, v0, v1, v2, fp_vertices, fp_edges);
 }
 
 /*
@@ -287,7 +287,7 @@ void BR_ASM_CALL OpTriangleReplicateConstantRGB(brp_block *block, brp_vertex *v0
     v1->comp[C_G] = v2->comp[C_G] = v0->comp[C_G];
     v1->comp[C_B] = v2->comp[C_B] = v0->comp[C_B];
 
-    block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges);
+    brp_render3_fp(block->chain, v0, v1, v2, fp_vertices, fp_edges);
 }
 
 void BR_ASM_CALL OpTriangleToPoints(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2, br_uint_16 (*fp_vertices)[3])
@@ -296,17 +296,17 @@ void BR_ASM_CALL OpTriangleToPoints(brp_block *block, brp_vertex *v0, brp_vertex
      * Generate a point for each unrendered vertex
      */
     if(!rend.vertex_flags[(*fp_vertices)[0]] && !(v0->flags & OUTCODES_ALL)) {
-        block->chain->render(block->chain, v0);
+        brp_render1(block->chain, v0);
         rend.vertex_flags[(*fp_vertices)[0]] = 1;
     }
 
     if(!rend.vertex_flags[(*fp_vertices)[1]] && !(v1->flags & OUTCODES_ALL)) {
-        block->chain->render(block->chain, v1);
+        brp_render1(block->chain, v1);
         rend.vertex_flags[(*fp_vertices)[1]] = 1;
     }
 
     if(!rend.vertex_flags[(*fp_vertices)[2]] && !(v2->flags & OUTCODES_ALL)) {
-        block->chain->render(block->chain, v2);
+        brp_render1(block->chain, v2);
         rend.vertex_flags[(*fp_vertices)[2]] = 1;
     }
 }
@@ -317,17 +317,17 @@ void BR_ASM_CALL OpTriangleToPoints_OS(brp_block *block, brp_vertex *v0, brp_ver
      * Generate a point for each unrendered vertex
      */
     if(!rend.vertex_flags[(*fp_vertices)[0]]) {
-        block->chain->render(block->chain, v0);
+        brp_render1(block->chain, v0);
         rend.vertex_flags[(*fp_vertices)[0]] = 1;
     }
 
     if(!rend.vertex_flags[(*fp_vertices)[1]]) {
-        block->chain->render(block->chain, v1);
+        brp_render1(block->chain, v1);
         rend.vertex_flags[(*fp_vertices)[1]] = 1;
     }
 
     if(!rend.vertex_flags[(*fp_vertices)[2]]) {
-        block->chain->render(block->chain, v2);
+        brp_render1(block->chain, v2);
         rend.vertex_flags[(*fp_vertices)[2]] = 1;
     }
 }
@@ -482,7 +482,7 @@ static void triangleSubdivideOnScreen(int depth, brp_block *block, brp_vertex *v
         triangleSubdivideOnScreen(depth - 1, block, v1, &mid1, &mid0, fp_vertices, fp_edges, fp_eqn, tfp);
         triangleSubdivideOnScreen(depth - 1, block, v2, &mid2, &mid1, fp_vertices, fp_edges, fp_eqn, tfp);
     } else {
-        block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges, fp_eqn, tfp);
+        brp_render3_fpx(block->chain, v0, v1, v2, fp_vertices, fp_edges, fp_eqn, tfp);
     }
 }
 
@@ -506,7 +506,7 @@ static void triangleSubdivideCheck(int depth, brp_block *block, brp_vertex *v0, 
         triangleSubdivide(depth - 1, block, v1, &mid1, &mid0, fp_vertices, fp_edges, fp_eqn, tfp);
         triangleSubdivide(depth - 1, block, v2, &mid2, &mid1, fp_vertices, fp_edges, fp_eqn, tfp);
     } else {
-        block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges, fp_eqn, tfp);
+        brp_render3_fpx(block->chain, v0, v1, v2, fp_vertices, fp_edges, fp_eqn, tfp);
     }
 }
 

--- a/drivers/softrend/ffront.c
+++ b/drivers/softrend/ffront.c
@@ -21,7 +21,7 @@ void BR_ASM_CALL RenderForceFront1(brp_block *block, brp_vertex *v0)
 
     v[0].comp[C_SZ] = BR_SCALAR(0.0);
 
-    block->chain->render(block->chain, v + 0);
+    brp_render1(block->chain, v + 0);
 }
 
 void BR_ASM_CALL RenderForceFront2(brp_block *block, brp_vertex *v0, brp_vertex *v1)
@@ -34,7 +34,7 @@ void BR_ASM_CALL RenderForceFront2(brp_block *block, brp_vertex *v0, brp_vertex 
     v[0].comp[C_SZ] = BR_SCALAR(0.0);
     v[1].comp[C_SZ] = BR_SCALAR(0.0);
 
-    block->chain->render(block->chain, v + 0, v + 1);
+    brp_render2(block->chain, v + 0, v + 1);
 }
 
 void BR_ASM_CALL RenderForceFront3(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2)
@@ -49,7 +49,7 @@ void BR_ASM_CALL RenderForceFront3(brp_block *block, brp_vertex *v0, brp_vertex 
     v[1].comp[C_SZ] = BR_SCALAR(0.0);
     v[2].comp[C_SZ] = BR_SCALAR(0.0);
 
-    block->chain->render(block->chain, v + 0, v + 1, v + 2);
+    brp_render3(block->chain, v + 0, v + 1, v + 2);
 }
 
 void BR_ASM_CALL RenderForceFront4(brp_block *block, brp_vertex *v0, brp_vertex *v1, brp_vertex *v2, brp_vertex *v3)
@@ -66,5 +66,5 @@ void BR_ASM_CALL RenderForceFront4(brp_block *block, brp_vertex *v0, brp_vertex 
     v[2].comp[C_SZ] = BR_SCALAR(0.0);
     v[3].comp[C_SZ] = BR_SCALAR(0.0);
 
-    block->chain->render(block->chain, v + 0, v + 1, v + 2, v + 3);
+    brp_render4(block->chain, v + 0, v + 1, v + 2, v + 3);
 }

--- a/drivers/softrend/gv1buckt.c
+++ b/drivers/softrend/gv1buckt.c
@@ -137,7 +137,7 @@ br_error BR_CMETHOD_DECL(br_geometry_v1_buckets_soft, render)(br_geometry_v1_buc
             /*
              * Render the primitive
              */
-            rend.block->render(rend.block, p->v[0], p->v[1], p->v[2]);
+            brp_render3(rend.block, p->v[0], p->v[1], p->v[2]);
         }
     }
 

--- a/drivers/softrend/mapping.c
+++ b/drivers/softrend/mapping.c
@@ -230,5 +230,5 @@ void BR_ASM_CALL OpTriangleMapQuad(brp_block *block, brp_vertex *v0, brp_vertex 
             break;
     }
 
-    block->chain->render(block->chain, v0, v1, v2, fp_vertices, fp_edges, fp_eqn, tfp);
+    brp_render3_fpx(block->chain, v0, v1, v2, fp_vertices, fp_edges, fp_eqn, tfp);
 }

--- a/drivers/softrend/v1model.c
+++ b/drivers/softrend/v1model.c
@@ -402,11 +402,11 @@ static void GEOMETRY_CALL V1Face_Render(br_geometry *self, br_renderer *renderer
         rend.current_index = f;
 
         if(tfp->flag & TFF_CLIPPED) {
-            clipped->render(clipped, rend.temp_vertices + (*fp_vertices)[0], rend.temp_vertices + (*fp_vertices)[1],
-                            rend.temp_vertices + (*fp_vertices)[2], fp_vertices, fp_edges, fp_eqn, tfp);
+            brp_render3_fpx(clipped, rend.temp_vertices + (*fp_vertices)[0], rend.temp_vertices + (*fp_vertices)[1],
+                          rend.temp_vertices + (*fp_vertices)[2], fp_vertices, fp_edges, fp_eqn, tfp);
         } else {
-            unclipped->render(unclipped, rend.temp_vertices + (*fp_vertices)[0], rend.temp_vertices + (*fp_vertices)[1],
-                              rend.temp_vertices + (*fp_vertices)[2], fp_vertices, fp_edges, fp_eqn, tfp);
+            brp_render3_fpx(unclipped, rend.temp_vertices + (*fp_vertices)[0], rend.temp_vertices + (*fp_vertices)[1],
+                          rend.temp_vertices + (*fp_vertices)[2], fp_vertices, fp_edges, fp_eqn, tfp);
         }
     }
 }
@@ -430,10 +430,8 @@ void GEOMETRY_CALL V1Face_OS_Render(br_geometry *self, struct br_renderer *rende
 
             rend.current_index = f;
 
-#if 1
-            unclipped->render(unclipped, rend.temp_vertices + (*fp_vertices)[0], rend.temp_vertices + (*fp_vertices)[1],
-                              rend.temp_vertices + (*fp_vertices)[2], fp_vertices, fp_edges, fp_eqn, tfp);
-#endif
+            brp_render3_fpx(unclipped, rend.temp_vertices + (*fp_vertices)[0], rend.temp_vertices + (*fp_vertices)[1],
+                          rend.temp_vertices + (*fp_vertices)[2], fp_vertices, fp_edges, fp_eqn, tfp);
         }
     }
 }
@@ -456,8 +454,8 @@ void GEOMETRY_CALL V1Face_OSV_Render(br_geometry *self, struct br_renderer *rend
 
         rend.current_index = f;
 
-        unclipped->render(unclipped, rend.temp_vertices + (*fp_vertices)[0], rend.temp_vertices + (*fp_vertices)[1],
-                          rend.temp_vertices + (*fp_vertices)[2], fp_vertices, fp_edges, fp_eqn, tfp);
+        brp_render3_fpx(unclipped, rend.temp_vertices + (*fp_vertices)[0], rend.temp_vertices + (*fp_vertices)[1],
+                      rend.temp_vertices + (*fp_vertices)[2], fp_vertices, fp_edges, fp_eqn, tfp);
     }
 }
 


### PR DESCRIPTION
On ARM64 (Apple Silicon and other ARM64 platforms), `brp_render_fn` is
declared variadic (...), which causes the compiler to use the variadic
calling convention — passing args on the stack. Actual render functions
are non-variadic and expect args in registers. The mismatch silently
corrupts vertex data, producing garbage output or crashes on ARM64.

## Fix

Add static inline wrappers in `ddi/priminfo.h` that cast through the
correct non-variadic function pointer type before calling:

- `brp_render1` / `brp_render2` / `brp_render3`
- `brp_render3e2` / `brp_render3e4` / `brp_render4`

Replace all `block->render(...)` call sites in softrend with the
appropriate wrapper.

## Zero cost on x86

On x86/x86-64, the variadic and non-variadic calling conventions are
identical, so the casts are no-ops and there is no behavioral or
performance change on existing platforms.

## Testing

Verified on Apple M4 (arm64): softrend renders correctly after this fix.
Cube scene with flat-shaded triangles produces expected output.

<img width="1280" height="720" alt="softcube24" src="https://github.com/user-attachments/assets/c8ad5529-15c1-4e2a-a9e3-eedacb21006a" />
