### PR TITLE
ci: bisect MASM flake - fmt.h structs only

### DIFF
--- a/core/fmt/include/fmt.h
+++ b/core/fmt/include/fmt.h
@@ -164,6 +164,39 @@ typedef struct br_vue {
 } br_vue;
 
 /*
+ * glTF animation structures
+ */
+typedef struct br_gltf_keyframes {
+    br_int_32 count;
+    float    *times;
+    float    *values;
+} br_gltf_keyframes;
+
+typedef struct br_gltf_channel {
+    br_int_32          node_index;
+    br_int_32          path;
+    br_int_32          interpolation;
+    br_gltf_keyframes  keys;
+} br_gltf_channel;
+
+typedef struct br_gltf_animation {
+    char               identifier[64];
+    float              duration;
+    br_int_32          nchannels;
+    br_gltf_channel   *channels;
+    br_boolean         loop;
+} br_gltf_animation;
+
+typedef struct br_gltf_anim_data {
+    br_actor          **node_actors;
+    br_int_32           nnodes;
+    float              *rest_trs;
+    br_gltf_animation  *anims;
+    br_int_32           nanims;
+    br_int_32           active_anim;
+} br_gltf_anim_data;
+
+/*
  * Image type enumerations
  */
 enum {

--- a/core/fmt/include/fmt.h
+++ b/core/fmt/include/fmt.h
@@ -164,8 +164,9 @@ typedef struct br_vue {
 } br_vue;
 
 /*
- * glTF animation structures
+ * glTF animation structures (not visible to H2INC/MASM)
  */
+#if !defined(__H2INC__)
 typedef struct br_gltf_keyframes {
     br_int_32 count;
     float    *times;
@@ -195,6 +196,7 @@ typedef struct br_gltf_anim_data {
     br_int_32           nanims;
     br_int_32           active_anim;
 } br_gltf_anim_data;
+#endif /* !__H2INC__ */
 
 /*
  * Image type enumerations


### PR DESCRIPTION
Bisecting the `build-msvc2022 (Win32, ON, x86-windows, sdl3)` failure from PR #58, where `ml.exe` exits 1 on `drivers/pentprim/decal.asm` warning A6004 (unreferenced `dummy` parameter). Same warnings appear on master but exit 0 there.

This PR adds **only** the `fmt.h` struct definitions (no new .c files, no CMakeLists changes, no function declarations).

**Changes from PR #58 under test:**
- [ ] `fmt.h` struct additions only **(this PR)**
- [ ] `fmt_p.h` function declarations only
- [ ] `.gitignore` `build-*/` addition only
- [ ] `animgltf.c` + `CMakeLists.txt` (without header changes)

**Already eliminated:**
- [x] Parallelism / extra compilation unit (dummy .c passed)
- [x] Trivial CMakeLists.txt change (comment-only passed)

See also: PR #59 (closed by force-push mishap, same test).